### PR TITLE
NESTOPIA action.config update to show .nes files

### DIFF
--- a/Menu/GameShell/20_Retro Games/NESTOPIA/action.config
+++ b/Menu/GameShell/20_Retro Games/NESTOPIA/action.config
@@ -1,6 +1,6 @@
 ROM=/home/cpi/games/NESTOPIA
 ROM_SO=/home/cpi/apps/emulators/nestopia_libretro.so
-EXT=zip
+EXT=zip,nes
 LAUNCHER=retroarch -L
 TITLE=NESTOPIA Roms
 SO_URL=http://buildbot.libretro.com/nightly/linux/armhf/latest/nestopia_libretro.so.zip


### PR DESCRIPTION
NESTOPIA supports .nes files too. With this change .nes files should show up in the retro games > NESTOPIA section as long as they are in the /home/cpi/games/NESTOPIA directory.