### PR TITLE
Add EXCLUDE parameter for emulator config

### DIFF
--- a/sys.py/UI/Emulator/rom_list_page.py
+++ b/sys.py/UI/Emulator/rom_list_page.py
@@ -4,6 +4,7 @@ import os
 import pygame
 
 import glob
+import re
 import shutil
 import gobject
 import validators
@@ -150,11 +151,18 @@ class RomListPage(Page):
                 
                 bname = os.path.basename(v)  ### filter extension
                 if len(bname)> 1:
-                    pieces  = bname.split(".")
-                    if len(pieces) > 1:
-                        if pieces[ len(pieces)-1   ].lower() in self._Emulator["EXT"]:
-                            dirmap["file"] = v
-                            ret.append(dirmap)
+                    is_excluded = False
+                    for exclude_pattern in self._Emulator["EXCLUDE"]:
+                        if re.match(exclude_pattern, bname):
+                            is_excluded = True
+                            break
+
+                    if not is_excluded:
+                        pieces  = bname.split(".")
+                        if len(pieces) > 1:
+                            if pieces[ len(pieces)-1   ].lower() in self._Emulator["EXT"]:
+                                dirmap["file"] = v
+                                ret.append(dirmap)
 #            else:
 #                print("not file or dir")
 

--- a/sys.py/UI/main_screen.py
+++ b/sys.py/UI/main_screen.py
@@ -440,6 +440,7 @@ class MainScreen(object):
                         obj["ROM"] = ""
                         obj["ROM_SO"] =""
                         obj["EXT"]    = []
+                        obj["EXCLUDE"] = []
                         obj["FILETYPE"] = "file"
                         obj["LAUNCHER"] = ""
                         obj["TITLE"]    = "Game"
@@ -458,6 +459,8 @@ class MainScreen(object):
                             pis = c.split("=")
                             if len(pis) > 1:
                                 if "EXT" in pis[0]:
+                                    obj[pis[0]] = pis[1].split(",")
+                                elif "EXCLUDE" in pis[0]
                                     obj[pis[0]] = pis[1].split(",")
                                 else:
                                     obj[pis[0]] = pis[1]


### PR DESCRIPTION
For Neo Geo engine, we have to put a `neogeo.zip` file.

The `EXT` parameter is `zip`, so I cannot exclude this file.
