### PR TITLE
Allow LK1 and LK5 to switch keyboard layout

### DIFF
--- a/Menu/GameShell/10_Settings/Wifi/keyboard.py
+++ b/Menu/GameShell/10_Settings/Wifi/keyboard.py
@@ -304,14 +304,9 @@ class Keyboard(Page):
                 self._LeftOrRight = -1
             if self._SectionIndex >= (self._SectionNumbers -1):
                 self._LeftOrRight = 1
-            self.KeyboardShift()
 
-            self._SectionIndex -= self._LeftOrRight
+            self.ShiftKeyboardPage()
 
-            #print(self._SectionIndex) # on which keyboard section now
-            self.Draw()
-            self._Screen.SwapAndShow()
-        
         if event.key == CurKeys["Menu"]: # we assume keyboard always be child page
             self.ReturnToUpLevelPage()
             self._Screen.Draw()
@@ -329,6 +324,16 @@ class Keyboard(Page):
             self._Textarea.Draw()
             self._Screen.SwapAndShow()
 
+        if event.key == CurKeys["LK1"]:
+            if self._SectionIndex < self._SectionNumbers -1:
+                self._LeftOrRight = -1
+                self.ShiftKeyboardPage()
+                
+        if event.key == CurKeys["LK5"]:
+            if self._SectionIndex > 0:
+                self._LeftOrRight = 1 
+                self.ShiftKeyboardPage()
+
     def Draw(self):
         self.ClearCanvas()
         self._Ps.Draw()
@@ -340,4 +345,9 @@ class Keyboard(Page):
         
         self._Textarea.Draw()
 
+    def ShiftKeyboardPage(self):
+        self.KeyboardShift()
+        self._SectionIndex -= self._LeftOrRight
+        self.Draw()
+        self._Screen.SwapAndShow()
 

--- a/sys.py/UI/keys_def.py
+++ b/sys.py/UI/keys_def.py
@@ -34,6 +34,8 @@ GameShell["Space"] = pygame.K_SPACE
 GameShell["Enter"] = pygame.K_k
 GameShell["Start"] = pygame.K_RETURN
 
+GameShell["LK1"] = pygame.K_h
+GameShell["LK5"] = pygame.K_l
 
 PC = {}
 


### PR DESCRIPTION
I tried to use the Shift key to jump to second page, but seems like Shift key doesn't have event key. So I added light key 1 and 5 (left and right most) to navigate the Wifi keyboard layouts.

Keyboard mappings reference: 

![](https://discourse-cdn-sjc2.com/standard17/uploads/clockworkpi/optimized/1X/11c1191c4e9394779edaaed3958128d256fbf98c_1_690x391.jpg)
