### PR TITLE
Made it easier to change what menu item is selected by default

### DIFF
--- a/sys.py/UI/constants.py
+++ b/sys.py/UI/constants.py
@@ -19,6 +19,9 @@ Width = 320
 Height = 240
 bg_color =  SkinManager().GiveColor('White')
 
+# 1 is the value gameshell comes with
+default_menu_item = 0
+
 icon_width  = 80
 icon_height = 80
 icon_ext = ".sh"

--- a/sys.py/UI/icon_item.py
+++ b/sys.py/UI/icon_item.py
@@ -3,7 +3,7 @@
 import pygame
 
 ## local import
-from constants  import icon_width,icon_height,ICON_TYPES,ALIGN,icon_ext,Width,Height
+from constants  import icon_width,icon_height,default_menu_item,ICON_TYPES,ALIGN,icon_ext,Width,Height
 from util_funcs import color_surface,midRect
 from label      import Label
 
@@ -72,7 +72,7 @@ class IconItem:
             elif self._LinkPage._Align == ALIGN["SLeft"]:
                 self._LinkPage.AdjustSAutoLeftAlign()
                 if self._LinkPage._IconNumbers > 1:
-                    self._LinkPage._PsIndex = 1
+                    self._LinkPage._PsIndex = default_menu_item
                     self._LinkPage._IconIndex = self._LinkPage._PsIndex
 
     def CreateImageSurf(self):

--- a/sys.py/UI/main_screen.py
+++ b/sys.py/UI/main_screen.py
@@ -14,7 +14,7 @@ from datetime import datetime
 from beeprint import pp
 
 ## local package import
-from constants   import ICON_TYPES,icon_ext,icon_width,icon_height,RUNEVT
+from constants   import ICON_TYPES,icon_ext,icon_width,icon_height,default_menu_item,RUNEVT
 from icon_item   import IconItem
 from page        import Page,PageStack
 from title_bar   import TitleBar
@@ -171,7 +171,7 @@ class MainScreen(object):
             self._Pages[i].Adjust()
             
             if self._Pages[i]._IconNumbers > 1:
-                self._Pages[i]._PsIndex = 1
+                self._Pages[i]._PsIndex = default_menu_item
                 self._Pages[i]._IconIndex = self._Pages[i]._PsIndex
             
                 

--- a/sys.py/UI/page.py
+++ b/sys.py/UI/page.py
@@ -13,7 +13,7 @@ from libs import easing
 #from beeprint import pp
 
 ### local import
-from constants    import ALIGN,icon_width,icon_height,Width,Height,ICON_TYPES
+from constants    import ALIGN,icon_width,icon_height,default_menu_item,Width,Height,ICON_TYPES
 from util_funcs   import midRect
 from keys_def     import CurKeys
 from icon_pool    import MyIconPool
@@ -166,7 +166,7 @@ class Page(object):
         self._OnShow = False
         
         if self._IconNumbers > 1:
-            self._PsIndex = 1
+            self._PsIndex = default_menu_item
             self._IconIndex = self._PsIndex
             self._PrevIconIndex = self._IconIndex
             self._Icons[self._IconIndex]._PosY -= self._SelectedIconTopOffset
@@ -218,7 +218,7 @@ class Page(object):
         self._OnShow = False
 
         if self._IconNumbers > 1:
-            self._PsIndex = 1
+            self._PsIndex = default_menu_item
             self._IconIndex = self._PsIndex
             self._PrevIconIndex = self._IconIndex
             self._Icons[self._IconIndex]._PosY -= self._SelectedIconTopOffset
@@ -298,7 +298,7 @@ class Page(object):
             self._OnShow = False
             
             if self._IconNumbers > 1:
-                self._PsIndex = 1
+                self._PsIndex = default_menu_item
                 self._IconIndex = self._PsIndex
                 self._PrevIconIndex = self._IconIndex
                 self._Icons[self._IconIndex]._PosY -= self._SelectedIconTopOffset


### PR DESCRIPTION
* pulled hard coded 1 that _PsIndex is reset to into default_menu_item constant
* set default_menu_item to 0, so the first menu item, instead of second is selected - this should be set to 1 for the default gameshell behavior