### PR TITLE
Fix UX for XBOX layout

### DIFF
--- a/Menu/GameShell/10_Settings/About/__init__.py
+++ b/Menu/GameShell/10_Settings/About/__init__.py
@@ -14,7 +14,7 @@ from UI.page   import Page,PageSelector
 from UI.label  import Label
 from UI.fonts  import fonts
 from UI.util_funcs import midRect
-from UI.keys_def   import CurKeys
+from UI.keys_def   import CurKeys, IsKeyMenuOrB
 from UI.scroller   import ListScroller
 from UI.icon_pool  import MyIconPool
 from UI.icon_item  import IconItem
@@ -300,7 +300,7 @@ class AboutPage(Page):
         self._Screen.SwapAndShow()
         
     def KeyDown(self,event):
-        if event.key == CurKeys["A"] or event.key == CurKeys["Menu"]:
+        if IsKeyMenuOrB(event.key):
             self.ReturnToUpLevelPage()
             self._Screen.Draw()
             self._Screen.SwapAndShow()

--- a/Menu/GameShell/10_Settings/Airplane/__init__.py
+++ b/Menu/GameShell/10_Settings/Airplane/__init__.py
@@ -14,7 +14,7 @@ from UI.page   import Page,PageSelector
 from UI.label  import Label
 from UI.fonts  import fonts
 from UI.util_funcs import midRect
-from UI.keys_def   import CurKeys
+from UI.keys_def   import CurKeys, IsKeyStartOrA, IsKeyMenuOrB
 from UI.scroller   import ListScroller
 from UI.icon_pool  import MyIconPool
 from UI.icon_item  import IconItem
@@ -24,7 +24,7 @@ from UI.lang_manager import MyLangManager
 from UI.multilabel import MultiLabel
 
 class AirplanePage(Page):
-    _FootMsg =  ["Nav","Rescue","","Back","Toggle"]
+    _FootMsg =  ["Nav","","Rescue","Back","Toggle"]
     _MyList = []
     _ListFontObj = MyLangManager.TrFont("varela13")
     
@@ -194,12 +194,12 @@ class AirplanePage(Page):
         self._Screen.SwapAndShow()
         
     def KeyDown(self,event):
-        if event.key == CurKeys["A"] or event.key == CurKeys["Menu"]:
+        if IsKeyMenuOrB(event.key):
             self.ReturnToUpLevelPage()
             self._Screen.Draw()
             self._Screen.SwapAndShow()
 
-        if event.key == CurKeys["B"]:
+        if IsKeyStartOrA(event.key):
             self.ToggleModeAni()
             """
             self.ToggleMode()

--- a/Menu/GameShell/10_Settings/Bluetooth/__init__.py
+++ b/Menu/GameShell/10_Settings/Bluetooth/__init__.py
@@ -17,7 +17,7 @@ from UI.page   import Page,PageSelector
 from UI.label  import Label
 from UI.fonts  import fonts
 from UI.util_funcs import midRect
-from UI.keys_def   import CurKeys
+from UI.keys_def   import CurKeys, IsKeyStartOrA, IsKeyMenuOrB
 from UI.scroller   import ListScroller
 from UI.icon_pool  import MyIconPool
 from UI.icon_item  import IconItem
@@ -39,12 +39,12 @@ class BleForgetConfirmPage(ConfirmPage):
     _ConfirmText = MyLangManager.Tr("ConfirmForgetQ")
     
     def KeyDown(self,event):
-        if event.key == CurKeys["Menu"] or event.key == CurKeys["A"]:
+        if IsKeyMenuOrB(event.key):
             self.ReturnToUpLevelPage()
             self._Screen.Draw()
             self._Screen.SwapAndShow()
             
-        if event.key == CurKeys["B"]:
+        if IsKeyStartOrA(event.key):
             self.SnapMsg(MyLangManager.Tr("Deleting"))
             self._Screen.Draw()
             self._Screen.SwapAndShow()
@@ -97,7 +97,7 @@ class BleInfoPageSelector(PageSelector):
                           (x,y,self._Width-4,h),self._BackgroundColor,4,0,self._BackgroundColor)
 
 class BleInfoPage(Page):
-    _FootMsg =  ["Nav","Disconnect","Forget","Back",""]
+    _FootMsg =  ["Nav","Forget","Disconnect","Back",""]
     _MyList = []
     _ListFontObj = MyLangManager.TrFont("varela15")
     _ListSmFontObj = fonts["varela12"]  # small font
@@ -266,7 +266,7 @@ class BleInfoPage(Page):
         self._Screen.SwapAndShow()
 
     def KeyDown(self,event):
-        if event.key == CurKeys["A"] or event.key == CurKeys["Menu"]:
+        if IsKeyMenuOrB(event.key):
             self.ReturnToUpLevelPage()
             self._Screen.Draw()
             self._Screen.SwapAndShow()
@@ -280,7 +280,7 @@ class BleInfoPage(Page):
             self._Screen.Draw()
             self._Screen.SwapAndShow()
         
-        if event.key == CurKeys["Enter"]:
+        if IsKeyStartOrA(event.key):
             self.Click()
             
         if event.key == CurKeys["X"]:
@@ -378,7 +378,7 @@ class BluetoothPage(Page):
     _BlockCb           = None
     
     _LastStatusMsg     = ""
-    _FootMsg           = ["Nav","Scan","Info","Back","TryConnect"]
+    _FootMsg           = ["Nav","Info","Scan","Back","TryConnect"]
     _Scroller          = None
     _ListFontObj       = fonts["notosanscjk15"]
 
@@ -637,7 +637,7 @@ class BluetoothPage(Page):
             
     def KeyDown(self,event):
         
-        if event.key == CurKeys["A"] or event.key == CurKeys["Menu"]:
+        if IsKeyMenuOrB(event.key):
             if self._Offline == True:
                 self.AbortedAndReturnToUpLevel()
                 return
@@ -688,7 +688,7 @@ class BluetoothPage(Page):
             self._Screen.Draw()
             self._Screen.SwapAndShow()
             
-        if event.key == CurKeys["B"]:
+        if IsKeyStartOrA(event.key):
             if self._Offline == False:
                 self.TryConnect()
 

--- a/Menu/GameShell/10_Settings/Bluetooth/agent.py
+++ b/Menu/GameShell/10_Settings/Bluetooth/agent.py
@@ -7,7 +7,7 @@ import dbus
 #from beeprint import pp
 from libs.roundrects import aa_round_rect
 from UI.page   import Page,PageSelector
-from UI.keys_def   import CurKeys
+from UI.keys_def   import CurKeys, IsKeyMenuOrB
 from libs.DBUS import  bus, adapter,devices
 
 
@@ -204,7 +204,7 @@ class BleAgentPairPage(Page):
         self._Screen._FootBar.ResetNavText()        
         
     def KeyDown(self,event):
-        if event.key == CurKeys["A"] or event.key == CurKeys["Menu"]:
+        if IsKeyMenuOrB(event.key):
             if self._dev_obj != None:
                 try:
                     self._dev_obj.CancelPairing()

--- a/Menu/GameShell/10_Settings/Brightness/brightness_page.py
+++ b/Menu/GameShell/10_Settings/Brightness/brightness_page.py
@@ -12,7 +12,7 @@ from UI.label  import Label
 from UI.icon_item import IconItem
 from UI.fonts  import fonts
 from UI.util_funcs import midRect
-from UI.keys_def   import CurKeys
+from UI.keys_def   import CurKeys, IsKeyMenuOrB
 from UI.slider     import Slider
 from UI.icon_pool  import MyIconPool
 from UI.multi_icon_item import MultiIconItem
@@ -161,7 +161,7 @@ class BrightnessPage(Page):
         
     def KeyDown(self,event):
         
-        if event.key == CurKeys["Menu"] or event.key == CurKeys["A"]:
+        if IsKeyMenuOrB(event.key):
             self.ReturnToUpLevelPage()
             self._Screen.Draw()
             self._Screen.SwapAndShow()

--- a/Menu/GameShell/10_Settings/ButtonsLayout/__init__.py
+++ b/Menu/GameShell/10_Settings/ButtonsLayout/__init__.py
@@ -72,12 +72,12 @@ class UpdateConfirmPage(ConfirmPage):
             self._Screen.SwapAndShow()
             return
 
-        if event.key == CurKeys["Menu"] or event.key == CurKeys["A"]:
+        if IsKeyMenuOrB(event.key):
             self.ReturnToUpLevelPage()
             self._Screen.Draw()
             self._Screen.SwapAndShow()
 
-        if event.key == CurKeys["B"]:
+        if IsKeyStartOrA(event.key):
 
             if self._LayoutMode == "xbox":
                 keymap = ["j","k","u","i"]

--- a/Menu/GameShell/10_Settings/ButtonsLayout/__init__.py
+++ b/Menu/GameShell/10_Settings/ButtonsLayout/__init__.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*- 
+# -*- coding: utf-8 -*-
 
 import pygame
 import commands
@@ -11,7 +11,7 @@ from UI.page   import Page,PageSelector
 from UI.label  import Label
 from UI.fonts  import fonts
 from UI.util_funcs import midRect
-from UI.keys_def   import CurKeys
+from UI.keys_def   import CurKeys, GetButtonsLayoutMode, SetButtonsLayoutMode, IsKeyStartOrA, IsKeyMenuOrB
 from UI.scroller   import ListScroller
 from UI.icon_pool  import MyIconPool
 from UI.icon_item  import IconItem
@@ -23,15 +23,15 @@ class UpdateConfirmPage(ConfirmPage):
     _ConfirmText = "Apply to RetroArch?"
     _RetroArchConf = "/home/cpi/.config/retroarch/retroarch.cfg"
     _LayoutMode = "Unknown"
-    
+
     def ModifyRetroArchConf(self,keys):
-    
+
         try:
             with open(self._RetroArchConf, mode="r") as f:
                 confarr = f.readlines()
         except:
             return "retroarch.cfg cannot open."
-    
+
         bka = bkb = bkx = bky = False
         try:
             for i, ln in enumerate(confarr):
@@ -50,35 +50,35 @@ class UpdateConfirmPage(ConfirmPage):
                     bky = True
         except:
             return "retroarch.cfg cannot parse."
-        
+
         if bka and bkb and bkx and bky:
             None
         else:
             return "retroarch.cfg validation error."
-        
+
         try:
             with open(self._RetroArchConf, mode="w") as f:
                 confarr = f.writelines(confarr)
         except:
             return "retroarch.cfg cannot write."
-        
+
         return "Completed! Your RA keymap: " + self._LayoutMode.upper()
-        
+
     def KeyDown(self,event):
-    
+
         def finalizeWithDialog(msg):
             self._Screen._MsgBox.SetText(msg)
             self._Screen._MsgBox.Draw()
             self._Screen.SwapAndShow()
             return
-        
+
         if event.key == CurKeys["Menu"] or event.key == CurKeys["A"]:
             self.ReturnToUpLevelPage()
             self._Screen.Draw()
             self._Screen.SwapAndShow()
-            
+
         if event.key == CurKeys["B"]:
-            
+
             if self._LayoutMode == "xbox":
                 keymap = ["j","k","u","i"]
             elif self._LayoutMode == "snes":
@@ -87,17 +87,17 @@ class UpdateConfirmPage(ConfirmPage):
                 finalizeWithDialog("Internal error.")
                 return
             print("mode: " + self._LayoutMode)
-            
+
             if not os.path.isfile(self._RetroArchConf):
                 finalizeWithDialog("retroarch.cfg was not found.")
                 return
-            
+
             try:
                 shutil.copyfile(self._RetroArchConf, self._RetroArchConf + ".blbak")
             except:
                 finalizeWithDialog("Cannot create .blbak")
                 return
-            
+
             finalizeWithDialog(self.ModifyRetroArchConf(keymap))
             return
 
@@ -105,24 +105,24 @@ class UpdateConfirmPage(ConfirmPage):
         self.ReturnToUpLevelPage()
         self._Screen.Draw()
         self._Screen.SwapAndShow()
-            
+
     def Draw(self):
         self.ClearCanvas()
         self.DrawBG()
         for i in self._MyList:
             i.Draw()
-        
+
         self.Reset()
 
 class ButtonsLayoutPage(Page):
-    _FootMsg =  ["Nav.","UpdateRetroArch","","Back","Toggle"]
+    _FootMsg =  ["Nav.","","UpdateRetroArch","Back","Toggle"]
     _MyList = []
     _ListFontObj = fonts["varela13"]
-    
+
     _AList = {}
 
     _Scrolled = 0
-    
+
     _BGwidth = 320
     _BGheight = 240-24-20
 
@@ -133,24 +133,24 @@ class ButtonsLayoutPage(Page):
     _EasingDur = 30
 
     _dialog_index = 0
-    
+
     def __init__(self):
         Page.__init__(self)
         self._Icons = {}
 
     def GenList(self):
-        
+
         self._MyList = []
-        
-        
-            
+
+
+
     def Init(self):
         if self._Screen != None:
             if self._Screen._CanvasHWND != None and self._CanvasHWND == None:
                 self._HWND = self._Screen._CanvasHWND
                 self._CanvasHWND = pygame.Surface( (self._Screen._Width,self._BGheight) )
 
-        self._PosX = self._Index*self._Screen._Width 
+        self._PosX = self._Index*self._Screen._Width
         self._Width = self._Screen._Width ## equal to screen width
         self._Height = self._Screen._Height
 
@@ -172,7 +172,7 @@ class ButtonsLayoutPage(Page):
         self._Scroller.SetCanvasHWND(self._HWND)
 
         self._ConfirmPage = UpdateConfirmPage()
-        self._ConfirmPage._LayoutMode = self.GetButtonsLayoutMode()
+        self._ConfirmPage._LayoutMode = GetButtonsLayoutMode()
         self._ConfirmPage._Screen = self._Screen
         self._ConfirmPage._Name  = "Overwrite RA conf"
         self._ConfirmPage._Parent = self
@@ -184,38 +184,23 @@ class ButtonsLayoutPage(Page):
         if abs(self._Scrolled) <  (self._BGheight - self._Height)/2 + 0:
             self._PosY -= dis
             self._Scrolled -= dis
-        
+
     def ScrollUp(self):
         dis = 10
         if self._PosY < 0:
             self._PosY += dis
             self._Scrolled += dis
 
-    def GetButtonsLayoutMode(self):
-        lm = "xbox"
-        try:
-            with open(".buttonslayout", "r") as f:
-                lm = f.read()
-        except:
-            None
-        if lm not in ["xbox","snes"]:
-            lm = "xbox"
-        return lm
-
     def ToggleMode(self):
-        
-        if self.GetButtonsLayoutMode() == "xbox":
-            
-            with open(".buttonslayout", "w") as f:
-                f.write("snes")
-            
+
+        if GetButtonsLayoutMode() == "xbox":
+            SetButtonsLayoutMode("snes")
+
             self._dialog_index = 1
             self._Screen.Draw()
             self._Screen.SwapAndShow()
         else:
-
-            with open(".buttonslayout", "w") as f:
-                f.write("xbox")
+            SetButtonsLayoutMode("xbox")
 
             self._dialog_index = 0
             self._Screen.Draw()
@@ -225,39 +210,36 @@ class ButtonsLayoutPage(Page):
         self._Scrolled = 0
         self._PosY = 0
         self._DrawOnce = False
-        
-        if self.GetButtonsLayoutMode() == "xbox":
-            self._dialog_index = 0
-        else:
-            self._dialog_index = 1
-        
+
+        self._dialog_index = 0 if GetButtonsLayoutMode() == "xbox" else 1
+
     def OnReturnBackCb(self):
         self.ReturnToUpLevelPage()
         self._Screen.Draw()
         self._Screen.SwapAndShow()
-        
+
     def KeyDown(self,event):
-        if event.key == CurKeys["A"] or event.key == CurKeys["Menu"]:
+        if IsKeyMenuOrB(event.key):
             self.ReturnToUpLevelPage()
             self._Screen.Draw()
             self._Screen.SwapAndShow()
 
-        if event.key == CurKeys["B"]:
+        if IsKeyStartOrA(event.key):
             self.ToggleMode()
-            
+
         if event.key == CurKeys["X"]:
-            self._ConfirmPage._LayoutMode = self.GetButtonsLayoutMode()
+            self._ConfirmPage._LayoutMode = GetButtonsLayoutMode()
             self._Screen.PushPage(self._ConfirmPage)
             self._Screen.Draw()
             self._Screen.SwapAndShow()
-                                
+
     def Draw(self):
         self.ClearCanvas()
 
-        self._Icons["DialogBoxs"].NewCoord(0,30)        
+        self._Icons["DialogBoxs"].NewCoord(0,30)
         self._Icons["DialogBoxs"]._IconIndex = self._dialog_index
         self._Icons["DialogBoxs"].DrawTopLeft()
-        
+
         if self._HWND != None:
             self._HWND.fill((255,255,255))
             self._HWND.blit(self._CanvasHWND,(self._PosX,self._PosY,self._Width, self._Height ) )
@@ -272,7 +254,7 @@ class APIOBJ(object):
         self._Page._Screen = main_screen
         self._Page._Name ="Buttons Layout"
         self._Page.Init()
-        
+
     def API(self,main_screen):
         if main_screen !=None:
             main_screen.PushPage(self._Page)
@@ -280,8 +262,8 @@ class APIOBJ(object):
             main_screen.SwapAndShow()
 
 OBJ = APIOBJ()
-def Init(main_screen):    
+def Init(main_screen):
     OBJ.Init(main_screen)
 def API(main_screen):
     OBJ.API(main_screen)
-    
+

--- a/Menu/GameShell/10_Settings/GateWay/__init__.py
+++ b/Menu/GameShell/10_Settings/GateWay/__init__.py
@@ -13,7 +13,7 @@ from UI.page   import Page,PageSelector
 from UI.label  import Label
 from UI.fonts  import fonts
 from UI.util_funcs import midRect,FileExists
-from UI.keys_def   import CurKeys
+from UI.keys_def   import CurKeys, IsKeyStartOrA, IsKeyMenuOrB
 from UI.scroller   import ListScroller
 from UI.icon_pool  import MyIconPool
 from UI.icon_item  import IconItem
@@ -76,7 +76,7 @@ class PageListItem(InfoPageListItem):
         pygame.draw.line(self._Parent._CanvasHWND,MySkinManager.GiveColor('Line'),(self._PosX,self._PosY+self._Height-1),(self._PosX+self._Width,self._PosY+self._Height-1),1)        
     
 class GateWayPage(Page):
-    _FootMsg =  ["Nav","","Clear All","Back","Select"]
+    _FootMsg =  ["Nav","Clear All","","Back","Select"]
     _MyList = []
     _ListFont = fonts["notosanscjk15"]
     
@@ -268,12 +268,12 @@ class GateWayPage(Page):
         self._Screen.SwapAndShow()
         """
     def KeyDown(self,event):
-        if event.key == CurKeys["A"] or event.key == CurKeys["Menu"]:
+        if IsKeyMenuOrB(event.key):
             self.ReturnToUpLevelPage()
             self._Screen.Draw()
             self._Screen.SwapAndShow()
 
-        if event.key == CurKeys["B"]:
+        if IsKeyStartOrA(event.key):
             self.Click()
             
         if event.key == CurKeys["Y"]:

--- a/Menu/GameShell/10_Settings/Languages/__init__.py
+++ b/Menu/GameShell/10_Settings/Languages/__init__.py
@@ -13,7 +13,7 @@ from UI.page   import Page,PageSelector
 from UI.label  import Label
 from UI.fonts  import fonts
 from UI.util_funcs import midRect
-from UI.keys_def   import CurKeys
+from UI.keys_def   import CurKeys, IsKeyStartOrA, IsKeyMenuOrB
 from UI.scroller   import ListScroller
 from UI.icon_pool  import MyIconPool
 from UI.icon_item  import IconItem
@@ -231,12 +231,12 @@ class LanguagesPage(Page):
         self._Screen.SwapAndShow()
         """
     def KeyDown(self,event):
-        if event.key == CurKeys["A"] or event.key == CurKeys["Menu"]:
+        if IsKeyMenuOrB(event.key):
             self.ReturnToUpLevelPage()
             self._Screen.Draw()
             self._Screen.SwapAndShow()
 
-        if event.key == CurKeys["B"]:
+        if IsKeyStartOrA(event.key):
             self.Click()
             
         if event.key == CurKeys["Up"]:

--- a/Menu/GameShell/10_Settings/Lima/__init__.py
+++ b/Menu/GameShell/10_Settings/Lima/__init__.py
@@ -13,7 +13,7 @@ from UI.page   import Page,PageSelector
 from UI.label  import Label
 from UI.fonts  import fonts
 from UI.util_funcs import midRect,FileExists
-from UI.keys_def   import CurKeys
+from UI.keys_def   import CurKeys, IsKeyStartOrA, IsKeyMenuOrB
 from UI.scroller   import ListScroller
 from UI.icon_pool  import MyIconPool
 from UI.icon_item  import IconItem
@@ -218,12 +218,12 @@ class GPUDriverPage(Page):
         self._Screen.SwapAndShow()
         """
     def KeyDown(self,event):
-        if event.key == CurKeys["A"] or event.key == CurKeys["Menu"]:
+        if IsKeyMenuOrB(event.key):
             self.ReturnToUpLevelPage()
             self._Screen.Draw()
             self._Screen.SwapAndShow()
 
-        if event.key == CurKeys["B"]:
+        if IsKeyStartOrA(event.key):
             self.Click()
             
         if event.key == CurKeys["Up"]:

--- a/Menu/GameShell/10_Settings/Notification/__init__.py
+++ b/Menu/GameShell/10_Settings/Notification/__init__.py
@@ -17,7 +17,7 @@ from UI.page   import Page,PageSelector
 from UI.label  import Label
 from UI.fonts  import fonts
 from UI.util_funcs import midRect,FileExists,IsExecutable
-from UI.keys_def   import CurKeys
+from UI.keys_def   import CurKeys, IsKeyStartOrA, IsKeyMenuOrB
 from UI.scroller   import ListScroller
 from UI.icon_pool  import MyIconPool
 from UI.icon_item  import IconItem
@@ -194,12 +194,12 @@ class NotificationPage(Page):
         self._Screen.SwapAndShow()
         
     def KeyDown(self,event):
-        if event.key == CurKeys["A"] or event.key == CurKeys["Menu"]:
+        if IsKeyMenuOrB(event.key):
             self.ReturnToUpLevelPage()
             self._Screen.Draw()
             self._Screen.SwapAndShow()
 
-        if event.key == CurKeys["B"]:
+        if IsKeyStartOrA(event.key):
             
             self._Screen._MsgBox.SetText("Applying")
             self._Screen._MsgBox.Draw()

--- a/Menu/GameShell/10_Settings/PowerOFF/__init__.py
+++ b/Menu/GameShell/10_Settings/PowerOFF/__init__.py
@@ -4,7 +4,7 @@ import pygame
 
 #UI lib
 from UI.constants    import RUNSYS
-from UI.keys_def     import CurKeys
+from UI.keys_def     import CurKeys, IsKeyStartOrA, IsKeyMenuOrB
 from UI.confirm_page import ConfirmPage
 from UI.lang_manager import MyLangManager
 import config
@@ -40,13 +40,13 @@ class PowerOffConfirmPage(ConfirmPage):
         
     def KeyDown(self,event):
         
-        if event.key == CurKeys["Menu"] or event.key == CurKeys["A"]:
+        if IsKeyMenuOrB(event.key):
             
             self.ReturnToUpLevelPage()
             self._Screen.Draw()
             self._Screen.SwapAndShow()
 
-        if event.key == CurKeys["B"]:
+        if IsKeyStartOrA(event.key):
             if self.CheckBattery() < 20:
                 cmdpath = "feh --bg-center gameshell/wallpaper/gameover.png;"
             else:

--- a/Menu/GameShell/10_Settings/PowerOptions/__init__.py
+++ b/Menu/GameShell/10_Settings/PowerOptions/__init__.py
@@ -14,7 +14,7 @@ from UI.page   import Page,PageSelector
 from UI.label  import Label
 from UI.fonts  import fonts
 from UI.util_funcs import midRect
-from UI.keys_def   import CurKeys
+from UI.keys_def   import CurKeys, IsKeyStartOrA, IsKeyMenuOrB
 from UI.scroller   import ListScroller
 from UI.icon_pool  import MyIconPool
 from UI.icon_item  import IconItem
@@ -268,7 +268,7 @@ class InfoPage(Page):
         """
     
     def KeyDown(self,event):
-        if event.key == CurKeys["A"] or event.key == CurKeys["Menu"]:
+        if IsKeyMenuOrB(event.key):
             self.ReturnToUpLevelPage()
             self._Screen.Draw()
             self._Screen.SwapAndShow()
@@ -290,7 +290,7 @@ class InfoPage(Page):
             i.Draw()
 
 class PowerOptionsPage(Page):
-    _FootMsg =  ["Nav","","Detail","Back","Select"]
+    _FootMsg =  ["Nav","Detail","","Back","Select"]
     _MyList = []
     _ListFont = fonts["notosanscjk15"]
     
@@ -461,12 +461,12 @@ class PowerOptionsPage(Page):
         self._Screen.SwapAndShow()
         """
     def KeyDown(self,event):
-        if event.key == CurKeys["A"] or event.key == CurKeys["Menu"]:
+        if IsKeyMenuOrB(event.key):
             self.ReturnToUpLevelPage()
             self._Screen.Draw()
             self._Screen.SwapAndShow()
 
-        if event.key == CurKeys["B"]:
+        if IsKeyStartOrA(event.key):
             self.Click()
             
         if event.key == CurKeys["Up"]:

--- a/Menu/GameShell/10_Settings/Sound/sound_page.py
+++ b/Menu/GameShell/10_Settings/Sound/sound_page.py
@@ -13,7 +13,7 @@ from UI.icon_item import IconItem
 from UI.label  import Label
 from UI.fonts  import fonts
 from UI.util_funcs import midRect
-from UI.keys_def   import CurKeys
+from UI.keys_def   import CurKeys, IsKeyMenuOrB
 from UI.slider     import Slider
 from UI.multi_icon_item import MultiIconItem
 
@@ -145,7 +145,7 @@ class SoundPage(Page):
         
     def KeyDown(self,event):
         
-        if event.key == CurKeys["Menu"] or event.key == CurKeys["A"]:
+        if IsKeyMenuOrB(event.key):
             self.ReturnToUpLevelPage()
             self._Screen.Draw()
             self._Screen.SwapAndShow()

--- a/Menu/GameShell/10_Settings/Time/timezone_lib_list_page.py
+++ b/Menu/GameShell/10_Settings/Time/timezone_lib_list_page.py
@@ -13,7 +13,7 @@ from UI.label  import Label
 from UI.fonts  import fonts
 from UI.icon_item import IconItem
 from UI.util_funcs import midRect
-from UI.keys_def   import CurKeys
+from UI.keys_def   import CurKeys, IsKeyStartOrA, IsKeyMenuOrB
 from UI.multi_icon_item import MultiIconItem
 from UI.icon_pool           import MyIconPool
 from UI.scroller   import ListScroller
@@ -230,7 +230,7 @@ class TimezoneListPage(Page):
         
     def KeyDown(self,event):
         
-        if event.key == CurKeys["Menu"] or event.key == CurKeys["A"]:
+        if IsKeyMenuOrB(event.key):
             
             self.ReturnToUpLevelPage()
             self._Screen.Draw()
@@ -255,7 +255,7 @@ class TimezoneListPage(Page):
             self._Screen.Draw()
             self._Screen.SwapAndShow()
                                      
-        if event.key == CurKeys["Enter"]:
+        if IsKeyStartOrA(event.key):
             self.Click()
             
     def Draw(self):

--- a/Menu/GameShell/10_Settings/Update/__init__.py
+++ b/Menu/GameShell/10_Settings/Update/__init__.py
@@ -15,7 +15,7 @@ from UI.icon_pool import MyIconPool
 from UI.label  import Label
 from UI.fonts  import fonts
 from UI.util_funcs import midRect,CmdClean,get_git_revision_short_hash
-from UI.keys_def import CurKeys
+from UI.keys_def import CurKeys, IsKeyStartOrA, IsKeyMenuOrB
 from UI.confirm_page import ConfirmPage
 from UI.download     import Download
 from UI.download_process_page import DownloadProcessPage
@@ -111,12 +111,12 @@ class UpdateConfirmPage(ConfirmPage):
     
     def KeyDown(self,event):
         global LauncherLoc
-        if event.key == CurKeys["Menu"] or event.key == CurKeys["A"]:
+        if IsKeyMenuOrB(event.key):
             self.ReturnToUpLevelPage()
             self._Screen.Draw()
             self._Screen.SwapAndShow()
             
-        if event.key == CurKeys["B"]:
+        if IsKeyStartOrA(event.key):
             if self._GIT == True:
                 cmdpath = "%s/update.sh %s" % (LauncherLoc,self._Version)
                 pygame.event.post( pygame.event.Event(RUNSH, message=cmdpath))
@@ -155,7 +155,7 @@ class UpdateConfirmPage(ConfirmPage):
 
 class UpdatePage(Page):
     _Icons = {}
-    _FootMsg = ["Nav","Check Update","","Back",""]
+    _FootMsg = ["Nav","","Check Update","Back",""]
 
     _ListFontObj = fonts["varela15"]    
     _ConfirmPage = None
@@ -277,7 +277,7 @@ class UpdatePage(Page):
         pass
 
     def KeyDown(self,event):
-        if event.key == CurKeys["Menu"] or event.key == CurKeys["A"]:
+        if IsKeyMenuOrB(event.key):
             self.ReturnToUpLevelPage()
             self._Screen.Draw()
             self._Screen.SwapAndShow()

--- a/Menu/GameShell/10_Settings/Wifi/wifi_list.py
+++ b/Menu/GameShell/10_Settings/Wifi/wifi_list.py
@@ -12,7 +12,7 @@ from UI.page   import Page,PageSelector
 from UI.label  import Label
 from UI.fonts  import fonts
 from UI.util_funcs import midRect,SwapAndShow
-from UI.keys_def   import CurKeys
+from UI.keys_def   import CurKeys, IsKeyStartOrA, IsKeyMenuOrB
 from UI.scroller   import ListScroller
 from UI.confirm_page import ConfirmPage
 from UI.skin_manager import MySkinManager
@@ -32,12 +32,12 @@ class WifiDisconnectConfirmPage(ConfirmPage):
     _ConfirmText = MyLangManager.Tr("ConfirmDisconnectQ")
     
     def KeyDown(self,event):
-        if event.key == CurKeys["Menu"] or event.key == CurKeys["A"]:
+        if IsKeyMenuOrB(event.key):
             self.ReturnToUpLevelPage()
             self._Screen.Draw()
             self._Screen.SwapAndShow()
             
-        if event.key == CurKeys["B"]:
+        if IsKeyStartOrA(event.key):
             self.SnapMsg(MyLangManager.Tr("Disconnecting"))
             self._Screen.Draw()
             self._Screen.SwapAndShow()
@@ -60,7 +60,7 @@ class WifiDisconnectConfirmPage(ConfirmPage):
         self.Reset()
         
 class WifiInfoPage(Page):
-    _FootMsg =  ["Nav","Disconnect","","Back",""]
+    _FootMsg =  ["Nav","","Disconnect","Back",""]
     _MyList = []
     _ListFontObj = MyLangManager.TrFont("varela15")
 
@@ -171,7 +171,7 @@ class WifiInfoPage(Page):
         self._Screen.SwapAndShow()
         
     def KeyDown(self,event):
-        if event.key == CurKeys["A"] or event.key == CurKeys["Menu"]:
+        if IsKeyMenuOrB(event.key):
             self.ReturnToUpLevelPage()
             self._Screen.Draw()
             self._Screen.SwapAndShow()
@@ -186,7 +186,7 @@ class WifiInfoPage(Page):
             self._Screen.SwapAndShow()
         
 
-        if event.key == CurKeys["Enter"]:
+        if IsKeyStartOrA(event.key):
             self.Click()
 
         if event.key == CurKeys["X"]:
@@ -264,7 +264,7 @@ class WifiList(Page):
     _BlockCb           = None
     
     _LastStatusMsg     = ""
-    _FootMsg           = ["Nav","Scan","Info","Back","Enter"]
+    _FootMsg           = ["Nav","Info","Scan","Back","Enter"]
     _EncMethods        = None
     _Scroller          = None
     _ListFontObj       = fonts["notosanscjk15"]
@@ -580,7 +580,7 @@ class WifiList(Page):
 #            print("UI blocking ...")
 #            return
         
-        if event.key == CurKeys["A"] or event.key == CurKeys["Menu"]:
+        if IsKeyMenuOrB(event.key):
             if self._Wireless != None:
                 wireless_connecting = self._Wireless.CheckIfWirelessConnecting()
                 if wireless_connecting:
@@ -605,7 +605,7 @@ class WifiList(Page):
             self._Screen.Draw()
             self._Screen.SwapAndShow()
             
-        if event.key == CurKeys["Enter"]: ## enter to set password,enter is B on GM
+        if IsKeyStartOrA(event.key): ## enter to set password,enter is B on GM
             if len(self._MyList) == 0:
                 return
             

--- a/Menu/GameShell/10_Settings/list_page.py
+++ b/Menu/GameShell/10_Settings/list_page.py
@@ -11,7 +11,7 @@ from UI.page   import Page,PageSelector
 from UI.label  import Label
 from UI.fonts  import fonts
 from UI.util_funcs import midRect,FileExists
-from UI.keys_def   import CurKeys
+from UI.keys_def   import CurKeys, IsKeyStartOrA, IsKeyMenuOrB
 from UI.scroller   import ListScroller
 from UI.skin_manager import MySkinManager
 from UI.lang_manager import MyLangManager
@@ -114,7 +114,7 @@ class ListPage(Page):
 
         
     def KeyDown(self,event):
-        if event.key == CurKeys["A"] or event.key == CurKeys["Menu"]:
+        if IsKeyMenuOrB(event.key):
             self.ReturnToUpLevelPage()
             self._Screen.Draw()
             self._Screen.SwapAndShow()
@@ -129,7 +129,7 @@ class ListPage(Page):
             self._Screen.SwapAndShow()
         
 
-        if event.key == CurKeys["Enter"]:
+        if IsKeyStartOrA(event.key):
             self.Click()
             
     def Draw(self):

--- a/Menu/GameShell/97_Music Player/mpd_spectrum_page.py
+++ b/Menu/GameShell/97_Music Player/mpd_spectrum_page.py
@@ -17,7 +17,7 @@ from UI.page   import Page,PageSelector
 from UI.label  import Label
 from UI.fonts  import fonts
 from UI.util_funcs import midRect
-from UI.keys_def   import CurKeys
+from UI.keys_def   import CurKeys, IsKeyStartOrA, IsKeyMenuOrB
 from UI.icon_item import IconItem
 from UI.icon_pool  import MyIconPool
 from UI.skin_manager import MySkinManager
@@ -265,7 +265,7 @@ class MPDSpectrumPage(Page):
             
     
     def KeyDown(self,event):
-        if event.key == CurKeys["Menu"] or event.key == CurKeys["A"]:
+        if IsKeyMenuOrB(event.key):
             try:
                 os.close(self._FIFO)
                 self._FIFO = None
@@ -280,13 +280,6 @@ class MPDSpectrumPage(Page):
             self.ReturnToUpLevelPage()
             self._Screen.Draw()
             self._Screen.SwapAndShow()
-
-        if event.key == CurKeys["Start"]:
-            self._Screen.Draw()
-            self._Screen.SwapAndShow()
-            
-        if event.key == CurKeys["Enter"]:
-            pass
 
         
     def Draw(self):

--- a/Menu/GameShell/97_Music Player/music_lib_list_page.py
+++ b/Menu/GameShell/97_Music Player/music_lib_list_page.py
@@ -11,7 +11,7 @@ from UI.label  import Label
 from UI.fonts  import fonts
 from UI.icon_item import IconItem
 from UI.util_funcs import midRect
-from UI.keys_def   import CurKeys
+from UI.keys_def   import CurKeys, IsKeyStartOrA, IsKeyMenuOrB
 from UI.multi_icon_item import MultiIconItem
 from UI.icon_pool           import MyIconPool
 from UI.scroller   import ListScroller
@@ -82,7 +82,7 @@ class MusicLibListPage(Page):
 
     _Icons = {}
     _Selector=None
-    _FootMsg = ["Nav","Scan","","Back","Add to Playlist"]
+    _FootMsg = ["Nav","","Scan","Back","Add to Playlist"]
     _MyList = []
     _SwapMyList = []
     _ListFont = fonts["notosanscjk15"]
@@ -226,7 +226,7 @@ class MusicLibListPage(Page):
         
     def KeyDown(self,event):
         
-        if event.key == CurKeys["Menu"] or event.key == CurKeys["Left"] or event.key == CurKeys["A"]:
+        if IsKeyMenuOrB(event.key) or event.key == CurKeys["Left"]:
             
             self.ReturnToUpLevelPage()
             self._Screen.Draw()
@@ -258,7 +258,7 @@ class MusicLibListPage(Page):
             self._Screen.Draw()
             self._Screen.SwapAndShow()
                                      
-        if event.key == CurKeys["Enter"]:
+        if IsKeyStartOrA(event.key):
             self.Click()
             
     def Draw(self):

--- a/Menu/GameShell/97_Music Player/play_list_page.py
+++ b/Menu/GameShell/97_Music Player/play_list_page.py
@@ -12,7 +12,7 @@ from UI.icon_item import IconItem
 from UI.label  import Label
 from UI.fonts  import fonts
 from UI.util_funcs import midRect
-from UI.keys_def   import CurKeys
+from UI.keys_def   import CurKeys, IsKeyStartOrA, IsKeyMenuOrB
 from UI.icon_pool  import MyIconPool
 from UI.skin_manager import MySkinManager
 from UI.lang_manager import MyLangManager
@@ -61,7 +61,7 @@ class PlayListPage(Page):
 
     _Icons = {}
     _Selector=None
-    _FootMsg = ["Nav","RTA","Remove","Back","Play/Pause"]
+    _FootMsg = ["Nav","Remove","RTA","Back","Play/Pause"]
     _MyList = []
     _ListFont = fonts["notosanscjk15"]
 
@@ -252,7 +252,7 @@ class PlayListPage(Page):
         self.SyncScroll()
         
     def KeyDown(self,event):
-        if event.key == CurKeys["A"] or event.key == CurKeys["Menu"]:
+        if IsKeyMenuOrB(event.key):
             if myvars.Poller != None:
                 myvars.Poller.stop()
                 self._CurSongTime=""
@@ -283,7 +283,7 @@ class PlayListPage(Page):
             self._Screen.Draw()
             self._Screen.SwapAndShow()
             
-        if event.key == CurKeys["Enter"]:
+        if IsKeyStartOrA(event.key):
             self.Click()
 
         if event.key == CurKeys["X"]: # start spectrum

--- a/Menu/GameShell/98_TinyCloud/__init__.py
+++ b/Menu/GameShell/98_TinyCloud/__init__.py
@@ -9,7 +9,7 @@ from UI.label  import Label
 from UI.fonts  import fonts
 from UI.icon_item import IconItem
 from UI.icon_pool import MyIconPool
-from UI.keys_def  import CurKeys
+from UI.keys_def  import CurKeys, IsKeyMenuOrB
 from UI.skin_manager import MySkinManager
 from UI.lang_manager import MyLangManager
 
@@ -174,12 +174,10 @@ class TinyCloudPage(Page):
         self.SetLabels()
 
     def KeyDown(self,event):
-        if event.key == CurKeys["A"] or event.key == CurKeys["Menu"]:
-            if self._FootMsg[3] == "Back":
-                self.ReturnToUpLevelPage()
-                self._Screen.Draw()
-                self._Screen.SwapAndShow()
-            return
+        if IsKeyMenuOrB(event.key):
+            self.ReturnToUpLevelPage()
+            self._Screen.Draw()
+            self._Screen.SwapAndShow()
         
     def Draw(self):
         if self._DrawOnce == False:

--- a/Menu/GameShell/99_PowerOFF/__init__.py
+++ b/Menu/GameShell/99_PowerOFF/__init__.py
@@ -4,7 +4,7 @@ import pygame
 
 #UI lib
 from UI.constants    import RUNSYS
-from UI.keys_def     import CurKeys
+from UI.keys_def     import CurKeys, IsKeyStartOrA, IsKeyMenuOrB
 from UI.confirm_page import ConfirmPage
 
 import config
@@ -12,7 +12,7 @@ import config
 class PowerOffConfirmPage(ConfirmPage):
     
     _ConfirmText = "Awaiting Input"
-    _FootMsg = ["Nav","Reboot","","Cancel","Shutdown"]
+    _FootMsg = ["Nav","","Reboot","Cancel","Shutdown"]
 
     def CheckBattery(self):
         try:
@@ -41,13 +41,12 @@ class PowerOffConfirmPage(ConfirmPage):
         
     def KeyDown(self,event):
         
-        if event.key == CurKeys["Menu"] or event.key == CurKeys["A"]:
-            
+        if IsKeyMenuOrB(event.key):
             self.ReturnToUpLevelPage()
             self._Screen.Draw()
             self._Screen.SwapAndShow()
 
-        if event.key == CurKeys["B"]:
+        if IsKeyStartOrA(event.key):
             if self.CheckBattery() < 20:
                 cmdpath = "feh --bg-center gameshell/wallpaper/gameover.png;"
             else:

--- a/sys.py/UI/Emulator/__init__.py
+++ b/sys.py/UI/Emulator/__init__.py
@@ -10,7 +10,7 @@ import sys
 ## local UI import
 from UI.delete_confirm_page import DeleteConfirmPage
 from UI.icon_pool           import MyIconPool
-from UI.keys_def            import CurKeys
+from UI.keys_def            import CurKeys, IsKeyStartOrA, IsKeyMenuOrB
 from UI.lang_manager        import MyLangManager
 
 from rom_list_page import RomListPage
@@ -20,14 +20,14 @@ class FavDeleteConfirmPage(DeleteConfirmPage):
     
     def KeyDown(self,event):
         
-        if event.key == CurKeys["Menu"] or event.key == CurKeys["A"]:
+        if IsKeyMenuOrB(event.key):
             
             self.ReturnToUpLevelPage()
             self._Screen.Draw()
             self._Screen.SwapAndShow()
                 
         
-        if event.key == CurKeys["B"]:
+        if IsKeyStartOrA(event.key):
             try:
                 #self._FileName
                 stats = os.stat(self._FileName)

--- a/sys.py/UI/Emulator/fav_list_page.py
+++ b/sys.py/UI/Emulator/fav_list_page.py
@@ -13,7 +13,7 @@ from UI.label  import Label
 from UI.icon_item import IconItem
 from UI.fonts  import fonts
 from UI.util_funcs import midRect,CmdClean,FileExists
-from UI.keys_def   import CurKeys
+from UI.keys_def   import CurKeys, IsKeyStartOrA, IsKeyMenuOrB
 from UI.multi_icon_item import MultiIconItem
 from UI.icon_pool import MyIconPool
 from UI.scroller  import ListScroller
@@ -92,7 +92,7 @@ class FavListPage(Page):
 
     _Icons = {}
     _Selector=None
-    _FootMsg = ["Nav","Scan","Remove","","Run"]
+    _FootMsg = ["Nav","Remove","Scan","","Run"]
     _MyList = []
     _ListFont = fonts["notosanscjk15"]
     _MyStack = None
@@ -392,7 +392,7 @@ class FavListPage(Page):
     
     def KeyDown(self,event):
         
-        if event.key == CurKeys["Menu"] or event.key == CurKeys["Left"]: 
+        if IsKeyMenuOrB(event.key) or event.key == CurKeys["Left"]: 
             self.ReturnToUpLevelPage()
             self._Screen.Draw()
             self._Screen.SwapAndShow()
@@ -410,7 +410,7 @@ class FavListPage(Page):
             self._Screen.SwapAndShow()
         
 
-        if event.key == CurKeys["Enter"]:
+        if IsKeyStartOrA(event.key):
             self.Click()
 
                 

--- a/sys.py/UI/Emulator/rom_list_page.py
+++ b/sys.py/UI/Emulator/rom_list_page.py
@@ -20,7 +20,7 @@ from UI.label  import Label
 from UI.icon_item import IconItem
 from UI.fonts  import fonts
 from UI.util_funcs import midRect,CmdClean,FileExists
-from UI.keys_def   import CurKeys
+from UI.keys_def   import CurKeys, IsKeyStartOrA, IsKeyMenuOrB
 from UI.multi_icon_item import MultiIconItem
 from UI.icon_pool  import MyIconPool
 from UI.scroller   import ListScroller
@@ -99,7 +99,8 @@ class RomListPage(Page):
 
     _Icons = {}
     _Selector=None
-    _FootMsg = ["Nav","Scan","Del","AddFav","Run"]
+    # TODO: show "AddFav"
+    _FootMsg = ["Nav","Del","Scan","Back","Run"]
     _MyList = []
     _ListFont = fonts["notosanscjk15"]
     _MyStack = None
@@ -428,7 +429,7 @@ class RomListPage(Page):
 
     def KeyDown(self,event):
 
-        if event.key == CurKeys["Menu"] : 
+        if IsKeyMenuOrB(event.key): 
             self.ReturnToUpLevelPage()
             self._Screen.Draw()
             self._Screen.SwapAndShow()
@@ -451,10 +452,10 @@ class RomListPage(Page):
             self._Screen.Draw()
             self._Screen.SwapAndShow()
 
-        if event.key == CurKeys["Enter"]:
+        if IsKeyStartOrA(event.key):
             self.Click()
 
-        if event.key == CurKeys["A"]:
+        if event.key == CurKeys["Select"]:
             if len(self._MyList) == 0:
                 return
             

--- a/sys.py/UI/Emulator/rom_so_confirm_page.py
+++ b/sys.py/UI/Emulator/rom_so_confirm_page.py
@@ -14,7 +14,7 @@ from libs.roundrects import aa_round_rect
 
 from UI.confirm_page import ConfirmPage
 from UI.download_process_page import DownloadProcessPage
-from UI.keys_def   import CurKeys
+from UI.keys_def   import CurKeys, IsKeyStartOrA, IsKeyMenuOrB
 from UI.fonts  import fonts
 from UI.multilabel import MultiLabel
 from UI.lang_manager import MyLangManager
@@ -87,12 +87,12 @@ class RomSoConfirmPage(ConfirmPage):
         self._Screen.SwapAndShow()
     
     def KeyDown(self,event):    
-        if event.key == CurKeys["Menu"] or event.key == CurKeys["A"]:
+        if IsKeyMenuOrB(event.key):
             self.ReturnToUpLevelPage()
             self._Screen.Draw()
             self._Screen.SwapAndShow()
 
-        if event.key == CurKeys["B"]:
+        if IsKeyStartOrA(event.key):
             if self.CheckBattery() < 5:
                 self.SnapMsg(MyLangManager.Tr("BATOver5Pct"))
             else:

--- a/sys.py/UI/delete_confirm_page.py
+++ b/sys.py/UI/delete_confirm_page.py
@@ -11,7 +11,7 @@ from page   import Page,PageSelector
 from label  import Label
 from fonts  import fonts
 from util_funcs import midRect
-from keys_def   import CurKeys
+from keys_def   import CurKeys, IsKeyStartOrA, IsKeyMenuOrB
 from confirm_page import ConfirmPage
 from lang_manager import MyLangManager
 
@@ -32,14 +32,14 @@ class DeleteConfirmPage(ConfirmPage):
 
     def KeyDown(self,event):
 
-        if event.key == CurKeys["Menu"] or event.key == CurKeys["A"]:
+        if IsKeyMenuOrB(event.key):
 
             self.ReturnToUpLevelPage()
             self._Screen.Draw()
             self._Screen.SwapAndShow()
 
 
-        if event.key == CurKeys["B"]:
+        if IsKeyStartOrA(event.key):
             try:
                 os.remove(self._TrashDir+"/"+os.path.basename(self._FileName))
             except:

--- a/sys.py/UI/download_process_page.py
+++ b/sys.py/UI/download_process_page.py
@@ -15,7 +15,7 @@ from UI.label  import Label
 from UI.icon_item import IconItem
 from UI.fonts  import fonts
 from UI.util_funcs import midRect,CmdClean,FileExists
-from UI.keys_def   import CurKeys
+from UI.keys_def   import CurKeys, IsKeyMenuOrB
 from UI.multi_icon_item import MultiIconItem
 from UI.icon_pool  import MyIconPool
 from UI.download   import Download
@@ -176,7 +176,7 @@ class DownloadProcessPage(Page):
         self._DownloaderTimer = gobject.timeout_add(100, self.GObjectUpdateProcessInterval)
         
     def KeyDown(self,event):
-        if event.key == CurKeys["Menu"] or event.key == CurKeys["A"]:
+        if IsKeyMenuOrB(event.key):
             gobject.source_remove(self._DownloaderTimer)
             self._DownloaderTimer = -1
             

--- a/sys.py/UI/foot_bar.py
+++ b/sys.py/UI/foot_bar.py
@@ -1,10 +1,10 @@
-# -*- coding: utf-8 -*- 
+# -*- coding: utf-8 -*-
 
 import pygame
 import os
 
 
-##local import 
+##local import
 from constants  import Width,Height,ICON_TYPES,ALIGN
 from util_funcs import FileExists,midRect,SkinMap
 from icon_item  import IconItem
@@ -20,13 +20,13 @@ class FootBarIcon(MultiIconItem):
 
     def TotalWidth(self):
         return self._Width+self._Label._Width
-    
+
     def Draw(self):
         if self._Align==ALIGN["VCenter"]: #default
             if self._Label != None:
                 self._Label._PosX = self._PosX - self._Label._Width/2
                 self._Label._PosY = self._PosY + self._Height/2 + 12
-                
+
         elif self._Align ==ALIGN["HLeft"]:
             if self._Label != None:
                 self._Label._PosX = self._PosX + self._Width/2 + 3
@@ -34,7 +34,7 @@ class FootBarIcon(MultiIconItem):
 
         if self._Label!=None:
             self._Label.Draw()
-        
+
         if self._ImgSurf != None:
             self._Parent._CanvasHWND.blit(self._ImgSurf,midRect(self._PosX,
                                                                 self._PosY,
@@ -43,7 +43,7 @@ class FootBarIcon(MultiIconItem):
 class FootBar(Widget):
     _Width     = Width
     _Height    = 20
-    _BarHeight = 20.5 
+    _BarHeight = 20.5
     _BorderWidth = 1
     _CanvasHWND = None
     _HWND       = None
@@ -52,9 +52,9 @@ class FootBar(Widget):
     _IconHeight  = 18
     _LabelFont   = MyLangManager.TrFont("veramono10")
     _State       = "normal"
-    
+
     _SkinManager = None
-    
+
     def __init__(self):
         self._Icons = {}
 
@@ -66,21 +66,21 @@ class FootBar(Widget):
         keynames = ["nav","x","y","a","b"]
 
         share_surf = pygame.image.load(icon_base_path+"footbar.png").convert_alpha()
-        
+
         files = os.listdir(icondir)
         for _i,i in enumerate( keynames):
             it = FootBarIcon()
             it._MyType = ICON_TYPES["NAV"]
             it._Parent = self
             it._ImgSurf= share_surf
-            it._Align = ALIGN["HLeft"] # (x)text <= 
+            it._Align = ALIGN["HLeft"] # (x)text <=
 
             it.AddLabel("game",self._LabelFont)
             it.Adjust(self._IconWidth/2+_i*self._IconWidth, self._IconHeight/2+2, self._IconWidth, self._IconHeight,0)
             it._IconIndex = _i
             self._Icons[i] = it
 
-        
+
     def Init(self,screen):
         self._HWND       = screen
         self._CanvasHWND = pygame.Surface((Width,int(self._BarHeight)))
@@ -90,20 +90,20 @@ class FootBar(Widget):
         round_corners   =  MultiIconItem()
         round_corners._IconWidth = 10
         round_corners._IconHeight = 10
-        
+
         round_corners._MyType = ICON_TYPES["STAT"]
         round_corners._Parent = self
         round_corners._ImgSurf = MyIconPool._Icons["roundcorners"]
         round_corners.Adjust(0,0,10,10,0)
 
         self._Icons["round_corners"] = round_corners
-        
+
     def ResetNavText(self):
         self._Icons["nav"]._Label.SetText(MyLangManager.Tr("Nav"))
         self._State = "normal"
         self.Draw()
         return False
-        
+
     def UpdateNavText(self,texts):
         self._State = "tips"
         texts = MyLangManager.Tr(texts)
@@ -126,39 +126,25 @@ class FootBar(Widget):
             final_piece = text_slice
             if my_text.get_width() >= left_width:
                 break
-            
+
         print("finalpiece %s" %final_piece)
         self._Icons["nav"]._Label.SetText( final_piece )
 
         self.Draw()
-        
-    def GetButtonsLayoutMode(self):
-        lm = "xbox"
-        try:
-            with open(".buttonslayout", "r") as f:
-                lm = f.read()
-        except:
-            None
-        if lm not in ["xbox","snes"]:
-            lm = "xbox"
-        return lm
-        
+
     def SetLabelTexts(self,texts):
-        
-        barr = ["nav","x","y","a","b"]
-        if self.GetButtonsLayoutMode() == "snes":
-            barr = ["nav","y","x","b","a"]
-            
+        barr = ["nav","y","x","b","a"]
+
         for idx,x in enumerate(barr):
             try:
                 self._Icons[x]._Label.SetText(MyLangManager.Tr(texts[idx]))
             except IndexError:
                 print("Index "+x+" doesn't exist!")
 
-    
+
     def ClearCanvas(self):
         self._CanvasHWND.fill( self._SkinManager.GiveColor("White") )
-        
+
         self._Icons["round_corners"].NewCoord(5,self._Height -5 )
         self._Icons["round_corners"]._IconIndex = 2
         self._Icons["round_corners"].Draw()
@@ -167,14 +153,14 @@ class FootBar(Widget):
         self._Icons["round_corners"]._IconIndex = 3
         self._Icons["round_corners"].Draw()
 
-        
+
         """
-        aa_round_rect(self._CanvasHWND,  
+        aa_round_rect(self._CanvasHWND,
                     (0,0,self._Width,self._Height),self._BgColor,8,0, self._BgColor)
 
         pygame.draw.rect(self._CanvasHWND,self._BgColor,(0,0,Width,self._BarHeight/2), 0 )
         """
-        
+
     def Draw(self):
         self.ClearCanvas()
         self._Icons["nav"].NewCoord(self._IconWidth/2+3,self._IconHeight/2+2)
@@ -189,7 +175,7 @@ class FootBar(Widget):
                         _w += self._Icons[x].TotalWidth()
                     else:
                         _w += self._Icons[x].TotalWidth()+5
-                    
+
                     start_x = self._Width - _w
                     start_y = self._IconHeight/2+2
                     self._Icons[x].NewCoord(start_x,start_y)

--- a/sys.py/UI/keyboard.py
+++ b/sys.py/UI/keyboard.py
@@ -10,7 +10,7 @@ from UI.page   import Page,PageSelector
 from UI.label  import Label
 from UI.fonts  import fonts
 from UI.util_funcs import midRect
-from UI.keys_def import CurKeys
+from UI.keys_def import CurKeys, IsKeyStartOrA, IsKeyMenuOrB
 from UI.icon_item import IconItem
 from UI.icon_pool    import MyIconPool
 from UI.skin_manager import MySkinManager
@@ -63,7 +63,7 @@ class Keyboard(Page):
     _Textarea = None
     _Selector = None
     _LeftOrRight = 1
-    _FootMsg           = ["Nav.","ABC","Done","Backspace","Enter"]
+    _FootMsg           = ["Nav.","Done","ABC","Backspace","Enter"]
 
     _RowIndex    = 0
     _Caller   = None
@@ -291,7 +291,7 @@ class Keyboard(Page):
             self.SelectNextChar()
         if event.key == CurKeys["Left"]:
             self.SelectPrevChar()
-        if event.key == CurKeys["B"] or event.key == CurKeys["Enter"]:
+        if IsKeyStartOrA(event.key):
             self.ClickOnChar()
         if event.key == CurKeys["X"]:
             if self._SectionIndex <= 0:
@@ -317,7 +317,7 @@ class Keyboard(Page):
                         self._Caller.OnKbdReturnBackCb()
             #Uplevel page  invokes OnReturnBackCb,eg: ConfigWireless
 
-        if event.key == CurKeys["A"]:
+        if event.key == CurKeys["B"]:
             self._Textarea.RemoveFromLastText()
             self._Textarea.Draw()
             self._Screen.SwapAndShow()

--- a/sys.py/UI/keys_def.py
+++ b/sys.py/UI/keys_def.py
@@ -49,11 +49,7 @@ GameShell["Menu"] = pygame.K_ESCAPE
 
 SetXYABButtons(GetButtonsLayoutMode())
 
-GameShell["Vol-"] = pygame.K_SPACE
-GameShell["Vol+"] = pygame.K_RETURN
 GameShell["Select"] = pygame.K_SPACE
-
-GameShell["Enter"] = pygame.K_k # delete this
 GameShell["Start"] = pygame.K_RETURN
 
 GameShell["LK1"] = pygame.K_h
@@ -70,9 +66,6 @@ PC["X"]     = pygame.K_x
 PC["Y"]     = pygame.K_y
 PC["A"]     = pygame.K_a
 PC["B"]     = pygame.K_b
-PC["Vol-"]  = pygame.K_SPACE
-PC["Vol+"]  = pygame.K_RETURN
-PC["Enter"] = pygame.K_RETURN
 PC["Select"] = pygame.K_SPACE
 PC["Start"] = pygame.K_s
 

--- a/sys.py/UI/keys_def.py
+++ b/sys.py/UI/keys_def.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*- 
+# -*- coding: utf-8 -*-
 
 import pygame
 from pygame.locals import *
@@ -9,6 +9,36 @@ import sys
 
 from config import CurKeySet
 
+
+def GetButtonsLayoutMode():
+    lm = "xbox"
+    try:
+        with open(".buttonslayout", "r") as f:
+            lm = f.read()
+    except:
+        None
+    if lm not in ["xbox","snes"]:
+        lm = "xbox"
+    return lm
+
+def SetButtonsLayoutMode(mode):
+    SetXYABButtons(mode)
+    with open(".buttonslayout", "w") as f:
+        f.write(mode)
+
+def SetXYABButtons(mode):
+    if mode == "snes":
+        GameShell["Y"] = pygame.K_u
+        GameShell["X"] = pygame.K_i
+        GameShell["B"] = pygame.K_j
+        GameShell["A"] = pygame.K_k
+    else:
+        GameShell["X"] = pygame.K_u
+        GameShell["Y"] = pygame.K_i
+        GameShell["A"] = pygame.K_j
+        GameShell["B"] = pygame.K_k
+
+
 GameShell = {}
 GameShell["Up"]   = pygame.K_UP
 GameShell["Down"] = pygame.K_DOWN
@@ -16,16 +46,14 @@ GameShell["Left"] = pygame.K_LEFT
 GameShell["Right"]= pygame.K_RIGHT
 
 GameShell["Menu"] = pygame.K_ESCAPE
-GameShell["X"]    = pygame.K_u
-GameShell["Y"]    = pygame.K_i
-GameShell["A"]    = pygame.K_j
-GameShell["B"]    = pygame.K_k
+
+SetXYABButtons(GetButtonsLayoutMode())
 
 GameShell["Vol-"] = pygame.K_SPACE
 GameShell["Vol+"] = pygame.K_RETURN
-GameShell["Space"] = pygame.K_SPACE
+GameShell["Select"] = pygame.K_SPACE
 
-GameShell["Enter"] = pygame.K_k
+GameShell["Enter"] = pygame.K_k # delete this
 GameShell["Start"] = pygame.K_RETURN
 
 GameShell["LK1"] = pygame.K_h
@@ -45,7 +73,7 @@ PC["B"]     = pygame.K_b
 PC["Vol-"]  = pygame.K_SPACE
 PC["Vol+"]  = pygame.K_RETURN
 PC["Enter"] = pygame.K_RETURN
-PC["Space"] = pygame.K_SPACE
+PC["Select"] = pygame.K_SPACE
 PC["Start"] = pygame.K_s
 
 PC["LK1"] = pygame.K_h
@@ -55,3 +83,10 @@ if CurKeySet == "PC":
     CurKeys = PC
 else:
     CurKeys = GameShell
+
+
+def IsKeyStartOrA(key):
+    return key == CurKeys["Start"] or key == CurKeys["A"]
+
+def IsKeyMenuOrB(key):
+    return key == CurKeys["Menu"] or key == CurKeys["B"]

--- a/sys.py/UI/page.py
+++ b/sys.py/UI/page.py
@@ -15,7 +15,7 @@ from libs import easing
 ### local import
 from constants    import ALIGN,icon_width,icon_height,Width,Height,ICON_TYPES
 from util_funcs   import midRect
-from keys_def     import CurKeys
+from keys_def     import CurKeys, IsKeyStartOrA, IsKeyMenuOrB
 from icon_pool    import MyIconPool
 from lang_manager import MyLangManager
 from widget       import Widget
@@ -606,14 +606,7 @@ class Page(Widget):
                 self._MyList[i]._PosY -= self._MyList[i]._Height*dy
     
     def KeyDown(self,event):##default keydown,every inherited page class should have it's own KeyDown
-        if event.key == CurKeys["A"]:
-            if self._FootMsg[3] == "Back":
-                self.ReturnToUpLevelPage()
-                self._Screen.Draw()
-                self._Screen.SwapAndShow()
-                return
-    
-        if event.key == CurKeys["Menu"]:
+        if IsKeyMenuOrB(event.key):
             self.ReturnToUpLevelPage()
             self._Screen.Draw()
             self._Screen.SwapAndShow()
@@ -641,7 +634,7 @@ class Page(Widget):
                 self._Screen.Draw()
                 self._Screen.SwapAndShow()
                 
-        if event.key == CurKeys["Enter"]:
+        if IsKeyStartOrA(event.key):
             self.IconClick()
             self._Screen.Draw()
             self._Screen.SwapAndShow()


### PR DESCRIPTION
I changed meaning of buttons A and B for XBOX layout.
 "A" - "Enter/Accept"
"B" - "Escape/Back". 
I was opposite to it, so it confuses me every time after using real XBOX.

So "A" works the same as "Start" button and "B" as "Menu" so I added helpers `IsKeyStartOrA` ` IsKeyMenuOrB` and used them in every place where it was possible