### PR TITLE
Add support for pico-8 latest version pico-8_0.1.12c

### DIFF
--- a/Menu/GameShell/50_PICO-8/compkginfo.json
+++ b/Menu/GameShell/50_PICO-8/compkginfo.json
@@ -4,6 +4,6 @@
 "NotFoundMsg":["Please purchase the PICO-8 \n|None|varela16",
 "and copy it to the \"~/games/PICO-8\"|None|varela16"],
 
-"MD5":{"pico-8_0.1.11g_raspi.zip":"a3f2995cf117499f880bd964d6a0e1f2","pico-8_0.1.11g_amd64.zip":"6726141c784afd4a41be6b7414c1b932","pico-8_0.1.12_raspi.zip":"08eda95570e63089a2b9f5531503431e"},
+"MD5":{"pico-8_0.1.11g_raspi.zip":"a3f2995cf117499f880bd964d6a0e1f2","pico-8_0.1.11g_amd64.zip":"6726141c784afd4a41be6b7414c1b932","pico-8_0.1.12_raspi.zip":"08eda95570e63089a2b9f5531503431e","pico-8_0.1.12c_raspi.zip":"1a62b0d7d4e4be65f89f23ec9757cb66"},
 "Post-Up":"bash Post-Up.sh" 
 }


### PR DESCRIPTION
If you try to install the latest version of **pico-8** there's no version with _md5_ to compare with, this add the latest **pico-8_0.1.12c**.
In the future it should exist a better option, or every time a new version comes up you have to add the new version