### PR TITLE
fix broken wallpaper paths

### DIFF
--- a/Menu/GameShell/10_Settings/PowerOFF/__init__.py
+++ b/Menu/GameShell/10_Settings/PowerOFF/__init__.py
@@ -48,9 +48,9 @@ class PowerOffConfirmPage(ConfirmPage):
 
         if IsKeyStartOrA(event.key):
             if self.CheckBattery() < 20:
-                cmdpath = "feh --bg-center gameshell/wallpaper/gameover.png;"
+                cmdpath = "feh --bg-center ~/launcher/sys.py/gameshell/wallpaper/gameover.png;"
             else:
-                cmdpath = "feh --bg-center gameshell/wallpaper/seeyou.png;"
+                cmdpath = "feh --bg-center ~/launcher/sys.py/gameshell/wallpaper/seeyou.png;"
             
             cmdpath += "sleep 3;"
             

--- a/Menu/GameShell/99_PowerOFF/__init__.py
+++ b/Menu/GameShell/99_PowerOFF/__init__.py
@@ -49,9 +49,9 @@ class PowerOffConfirmPage(ConfirmPage):
 
         if IsKeyStartOrA(event.key):
             if self.CheckBattery() < 20:
-                cmdpath = "feh --bg-center gameshell/wallpaper/gameover.png;"
+                cmdpath = "feh --bg-center ~/launcher/sys.py/gameshell/wallpaper/gameover.png;"
             else:
-                cmdpath = "feh --bg-center gameshell/wallpaper/seeyou.png;"
+                cmdpath = "feh --bg-center ~/launcher/sys.py/gameshell/wallpaper/seeyou.png;"
             
             cmdpath += "sleep 3;"
             
@@ -61,7 +61,7 @@ class PowerOffConfirmPage(ConfirmPage):
             pygame.event.post( pygame.event.Event(RUNSYS, message=cmdpath))
             
         if event.key == CurKeys["X"]:
-            cmdpath = "feh --bg-center gameshell/wallpaper/seeyou.png;"
+            cmdpath = "feh --bg-center ~/launcher/sys.py/gameshell/wallpaper/seeyou.png;"
             cmdpath += "sleep 3;"
             cmdpath += "sudo reboot"
             pygame.event.post( pygame.event.Event(RUNSYS, message=cmdpath))

--- a/sys.py/UI/counter_screen.py
+++ b/sys.py/UI/counter_screen.py
@@ -41,7 +41,7 @@ class CounterScreen(FullScreen):
             print("do the real shutdown")
             
             if config.CurKeySet != "PC":
-                cmdpath = "feh --bg-center gameshell/wallpaper/seeyou.png;"
+                cmdpath = "feh --bg-center ~/launcher/sys.py/gameshell/wallpaper/seeyou.png;"
                 cmdpath += "sleep 3;"
                 cmdpath += "sudo halt -p"
                 pygame.event.post( pygame.event.Event(RUNSYS, message=cmdpath))\


### PR DESCRIPTION
The paths for the `gameover` and `seeyou` wallpapers are broken, as a result the `loading` wallpaper is displayed instead (i.e. on shutdown).

This patch fixes the issue.