### PR TITLE
Feature: wallpaper support for skin manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ retroarch-core-options.cfg
 sys.py/.powerlevel
 sys.py/.buttonslayout
 sys.py/.lang
+sys.py/gameshell/wallpaper_default
 *.cfg
 **/Jobs/*
 !**/Jobs/.gitkeep

--- a/Menu/GameShell/10_Settings/Skins/__init__.py
+++ b/Menu/GameShell/10_Settings/Skins/__init__.py
@@ -173,10 +173,29 @@ class SkinsPage(Page):
         self._Screen._MsgBox.Draw()
         self._Screen.SwapAndShow()
             
+        skin_flag_path = os.path.expanduser('~') + "/.gameshell_skin"
+        wallpaper_path = os.path.expanduser('~') + "/launcher/sys.py/gameshell/wallpaper"
+        wallpaper_backup_path = wallpaper_path + "_default"
+        wallpaper_skin_path = cur_li._Value + "/wallpaper"
+
         if "../skin/default" in cur_li._Value:
-            os.system("rm %s/.gameshell_skin" % os.path.expanduser('~') )
+            os.remove(skin_flag_path)
+            # restore default wallpaper if it was backed up
+            if os.path.islink(wallpaper_path) and os.path.isdir(wallpaper_backup_path):
+                os.remove(wallpaper_path)
+                os.rename(wallpaper_backup_path, wallpaper_path)
         else:
-            os.system("echo %s > %s/.gameshell_skin" % (cur_li._Value,os.path.expanduser('~') ))
+            os.system("echo %s > %s" % (cur_li._Value,skin_flag_path ))
+            # if the skin support wallpaper, backup and replace the default ones
+            if os.path.exists(wallpaper_skin_path):
+                # backup only for default skin
+                if not os.path.isdir(wallpaper_backup_path):
+                    os.rename(wallpaper_path, wallpaper_backup_path)
+                # delete current symlink if exist
+                if os.path.islink(wallpaper_path):
+                    os.remove(wallpaper_path)
+                # create new theme symlink
+                os.symlink(wallpaper_skin_path, wallpaper_path)
         
         pygame.time.delay(700)
         pygame.event.post( pygame.event.Event(RESTARTUI, message=""))


### PR DESCRIPTION
When using the theme manager, we can switch the `default` theme with any theme located in `/home/cpi/skins/*`. This currently supports most UI elements, except for `wallpaper`.

This means if we want to customize `loading` or `seeyou` wallpapers in our theme, we have to modify the launcher files directly, which is not ideal.

This feature will search for a `wallpaper` directory when switching to a new theme, and if it exists, will backup the default `wallpaper`, and replace it by a symlink to the theme one.

This has been tested with the OP-1 theme here
https://github.com/rqm/gameshell-skin-OP1