### PR TITLE
Fix the button texts in FootBar

### DIFF
--- a/sys.py/UI/foot_bar.py
+++ b/sys.py/UI/foot_bar.py
@@ -136,10 +136,8 @@ class FootBar(Widget):
         self.Draw()
 
     def SetLabelTexts(self,texts):
-        if config.ButtonsLayout == "xbox":
-            barr = ["nav","y","x","b","a","select"]
-        else:
-            barr = ["nav","x","y","a","b","select"]
+        barr = ["nav","y","x","b","a","select"]
+
         texts2 = texts + [""] if len(texts) == 5 else texts
 
         for idx,x in enumerate(barr):


### PR DESCRIPTION
The texts for the buttons in FootBar are not needed to change. Because the actual behavior is user will change the position of the real button caps. And the mapping of the functions and button caps is no changed.